### PR TITLE
Changed vault opening from vh to % on mobile

### DIFF
--- a/app/sass/_abstracts/_animations.scss
+++ b/app/sass/_abstracts/_animations.scss
@@ -1,17 +1,17 @@
 @include keyframes(vault-open-sm) {
     to {
-        @include size(100vw, calc(100vh - #{$header-h-sm * 2}));
+        @include size(100vw, calc(100% - #{$header-h-sm * 2}));
     }
     from {
-        @include size(100vw, calc(10vh - #{$header-h-sm * 2}));
+        @include size(100vw, calc(10% - #{$header-h-sm * 2}));
     }
 }
 @include keyframes(vault-open-md) {
     to {
-        @include size(100vw, calc(100vh - #{$header-h-md * 2}));
+        @include size(100vw, calc(100% - #{$header-h-md * 2}));
     }
     from {
-        @include size(100vw, calc(10vh - #{$header-h-md * 2}));
+        @include size(100vw, calc(10% - #{$header-h-md * 2}));
     }
 }
 @include keyframes(vault-open-lg) {

--- a/app/sass/molecules/_vault.scss
+++ b/app/sass/molecules/_vault.scss
@@ -8,7 +8,7 @@
         @extend %justify-center;
         flex-direction: column;
         position: fixed;
-        @include size(100vw, calc(100vh - #{$header-h-sm * 2}));
+        @include size(100vw, calc(100% - #{$header-h-sm * 2}));
         @include vault-animation(vault-open-sm);
         @include transform(translateZ(0));
         &__border {

--- a/app/styles.css
+++ b/app/styles.css
@@ -68,66 +68,66 @@ svg, .icon, .vault, .heading, .heading__projects > h1 {
 @-webkit-keyframes vault-open-sm {
   to {
     width: 100vw;
-    height: calc(100vh - 11rem); }
+    height: calc(100% - 11rem); }
   from {
     width: 100vw;
-    height: calc(10vh - 11rem); } }
+    height: calc(10% - 11rem); } }
 
 @-moz-keyframes vault-open-sm {
   to {
     width: 100vw;
-    height: calc(100vh - 11rem); }
+    height: calc(100% - 11rem); }
   from {
     width: 100vw;
-    height: calc(10vh - 11rem); } }
+    height: calc(10% - 11rem); } }
 
 @-o-keyframes vault-open-sm {
   to {
     width: 100vw;
-    height: calc(100vh - 11rem); }
+    height: calc(100% - 11rem); }
   from {
     width: 100vw;
-    height: calc(10vh - 11rem); } }
+    height: calc(10% - 11rem); } }
 
 @keyframes vault-open-sm {
   to {
     width: 100vw;
-    height: calc(100vh - 11rem); }
+    height: calc(100% - 11rem); }
   from {
     width: 100vw;
-    height: calc(10vh - 11rem); } }
+    height: calc(10% - 11rem); } }
 
 @-webkit-keyframes vault-open-md {
   to {
     width: 100vw;
-    height: calc(100vh - 13.5rem); }
+    height: calc(100% - 13.5rem); }
   from {
     width: 100vw;
-    height: calc(10vh - 13.5rem); } }
+    height: calc(10% - 13.5rem); } }
 
 @-moz-keyframes vault-open-md {
   to {
     width: 100vw;
-    height: calc(100vh - 13.5rem); }
+    height: calc(100% - 13.5rem); }
   from {
     width: 100vw;
-    height: calc(10vh - 13.5rem); } }
+    height: calc(10% - 13.5rem); } }
 
 @-o-keyframes vault-open-md {
   to {
     width: 100vw;
-    height: calc(100vh - 13.5rem); }
+    height: calc(100% - 13.5rem); }
   from {
     width: 100vw;
-    height: calc(10vh - 13.5rem); } }
+    height: calc(10% - 13.5rem); } }
 
 @keyframes vault-open-md {
   to {
     width: 100vw;
-    height: calc(100vh - 13.5rem); }
+    height: calc(100% - 13.5rem); }
   from {
     width: 100vw;
-    height: calc(10vh - 13.5rem); } }
+    height: calc(10% - 13.5rem); } }
 
 @-webkit-keyframes vault-open-lg {
   to {
@@ -1345,7 +1345,7 @@ ol > li > span {
     flex-direction: column;
     position: fixed;
     width: 100vw;
-    height: calc(100vh - 11rem);
+    height: calc(100% - 11rem);
     -moz-animation: vault-open-sm 1.5s ease-in-out;
     -webkit-animation: vault-open-sm 1.5s ease-in-out;
     -o-animation: vault-open-sm 1.5s ease-in-out;


### PR DESCRIPTION
Brave browser on mobile uses the viewport to display it's menus. This makes the browser think the viewport is higher than is should be and pushes the animation past the point is should be. Using % should fix this by looking at the body rather than the viewport.